### PR TITLE
Add daemon option

### DIFF
--- a/cli.yaml
+++ b/cli.yaml
@@ -24,3 +24,6 @@ args:
       value_name: seconds
       help: delay time before files are moved (defaults to 3 seconds)
       takes_value: true
+  - daemon:
+      long: daemon
+      help: run in the background

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,7 @@ pub struct Cli {
     pub(crate) config: PathBuf,
     pub(crate) watch: Vec<PathBuf>,
     pub(crate) delay: u8,
+    pub(crate) daemon: bool,
 }
 
 impl Cli {
@@ -68,10 +69,13 @@ impl Cli {
             None => 3,
         };
 
+        let daemon = matches.is_present("daemon");
+
         let cli = Cli {
             config,
             watch,
             delay,
+            daemon,
         };
 
         cli.validate_config()?

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,14 +8,31 @@ mod notifier;
 extern crate clap;
 use crate::config::Config;
 use crate::notifier::Notifier;
+use std::env;
+use std::process::Command;
 
 fn main() {
     let config = Config::new();
     match config {
+        Ok(config) if config.args.daemon => start_daemon(),
         Ok(config) => {
             let mut notifier = Notifier::new();
             notifier.watch(config);
         }
         Err(e) => eprintln!("{}", e),
     }
+}
+
+fn start_daemon() {
+    let mut args = env::args();
+    let command = args.next().unwrap(); // must've been started through a command
+    let args: Vec<_> = args.filter(|arg| arg != "--daemon").collect();
+
+    let pid = Command::new(command)
+        .args(&args)
+        .spawn()
+        .expect("couldn't start daemon")
+        .id();
+
+    println!("daemon started with PID {}", pid);
 }


### PR DESCRIPTION
Hi! This PR adds the daemon option that checks the config is correct and then restart the process in the background

This approach is cross-platform and avoids relying on external tools but as a side-effect the output cannot be redirected to a file in case an error happens, maybe `--daemon` should take a "path/to/output/file" value or this should be added along with logging?

Anyway, tell me if you want me to change anything

Have a nice day/night!